### PR TITLE
Fix code scanning alert no. 9: Disabled Spring CSRF protection

### DIFF
--- a/server/api-service/openblocks-server/src/main/java/com/openblocks/api/framework/security/SecurityConfig.java
+++ b/server/api-service/openblocks-server/src/main/java/com/openblocks/api/framework/security/SecurityConfig.java
@@ -67,7 +67,7 @@ public class SecurityConfig {
         http.cors()
                 .configurationSource(buildCorsConfigurationSource())
                 .and()
-                .csrf().disable()
+                .csrf().and()
                 .anonymous().principal(createAnonymousUser())
                 .and()
                 .httpBasic()


### PR DESCRIPTION
Fixes [https://github.com/limskey/openblocks/security/code-scanning/9](https://github.com/limskey/openblocks/security/code-scanning/9)

To fix the problem, we need to enable CSRF protection in the `SecurityConfig` class. This involves removing the line that disables CSRF protection and ensuring that CSRF protection is properly configured. We will modify the `securityWebFilterChain` method to enable CSRF protection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
