### PR TITLE
Fix code scanning alert no. 10: Disabled Spring CSRF protection

### DIFF
--- a/server/api-service/openblocks-server/src/test/java/com/openblocks/api/configurations/SecurityTestConfig.java
+++ b/server/api-service/openblocks-server/src/test/java/com/openblocks/api/configurations/SecurityTestConfig.java
@@ -12,6 +12,6 @@ public class SecurityTestConfig {
 
     @Bean
     public SecurityWebFilterChain testSecurityWebFilterChain(ServerHttpSecurity http) {
-        return http.csrf().disable().build();
+        return http.csrf().and().build();
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/limskey/openblocks/security/code-scanning/10](https://github.com/limskey/openblocks/security/code-scanning/10)

To fix the problem, we need to enable CSRF protection in the `SecurityTestConfig` class. This can be done by removing the call to `disable()` on the CSRF configuration. Instead, we should configure the CSRF protection appropriately. This change should be made in the `testSecurityWebFilterChain` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
