### PR TITLE
Fix code scanning alert no. 8: Inefficient regular expression

### DIFF
--- a/client/packages/openblocks/src/util/stringUtils.ts
+++ b/client/packages/openblocks/src/util/stringUtils.ts
@@ -61,7 +61,7 @@ export const COLOR_PALETTE = [
 
 export const PHONE_NUMBER_PATTERN = /^1\d{10}$/;
 export const EMAIL_PATTERN = /^[\w-+.]+@([\w-]+\.)+[\w-]{2,}$/;
-export const URL_PATTERN = /^(https?:\/\/)?([\w-])+\.{1}([a-zA-Z]{2,63})([/\w-]*)*\/?\??([^#\n\r]*)?#?([^\n\r]*)$/; // prettier-ignore
+export const URL_PATTERN = /^(https?:\/\/)?([\w-])+\.{1}([a-zA-Z]{2,63})([/\w]*-?)*\/?\??([^#\n\r]*)?#?([^\n\r]*)$/; // prettier-ignore
 
 export const checkOtpValid = (value: string): boolean => {
   return /^\d{6}$/.test(value);


### PR DESCRIPTION
Fixes [https://github.com/limskey/openblocks/security/code-scanning/8](https://github.com/limskey/openblocks/security/code-scanning/8)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. Specifically, we should change the part of the regular expression that matches `[/\w-]*` to avoid the ambiguity between matching `/` and `-`. One way to achieve this is to use a character class that explicitly excludes the `-` character when it is not at the beginning or end of the class.

- Modify the regular expression on line 64 to replace `[/\w-]*` with `[/\w]*-?`.
- This change ensures that the `-` character is matched separately, preventing the ambiguity that leads to exponential backtracking.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
