### PR TITLE
Fix code scanning alert no. 5: Client-side cross-site scripting

### DIFF
--- a/client/packages/openblocks/src/pages/userAuth/authUtils.ts
+++ b/client/packages/openblocks/src/pages/userAuth/authUtils.ts
@@ -67,11 +67,11 @@ export function authRespValidate(
   infoCompleteCheck: boolean,
   redirectUrl: string | null
 ) {
-  let replaceUrl = redirectUrl || BASE_URL;
+  let replaceUrl = getSafeAuthRedirectURL(redirectUrl);
   if (infoCompleteCheck) {
     // need complete info
     replaceUrl = redirectUrl
-      ? `${USER_INFO_COMPLETION}?redirectUrl=${redirectUrl}`
+      ? `${USER_INFO_COMPLETION}?redirectUrl=${getSafeAuthRedirectURL(redirectUrl)}`
       : USER_INFO_COMPLETION;
   }
   if (doValidResponse(resp)) {


### PR DESCRIPTION
Fixes [https://github.com/limskey/openblocks/security/code-scanning/5](https://github.com/limskey/openblocks/security/code-scanning/5)

To fix the problem, we need to ensure that the `redirectUrl` is always validated using the `isSafeRedirectURL` function before being used in `window.location.replace`. This will prevent any malicious scripts from being executed through the `redirectUrl`.

- Modify the `authRespValidate` function to use the `getSafeAuthRedirectURL` function to ensure the `redirectUrl` is safe.
- Ensure that the `getSafeAuthRedirectURL` function is used consistently throughout the code to validate the `redirectUrl`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
