### PR TITLE
Fix code scanning alert no. 3: Unvalidated dynamic method call

### DIFF
--- a/client/packages/openblocks/src/comps/comps/customComp/customComp.tsx
+++ b/client/packages/openblocks/src/comps/comps/customComp/customComp.tsx
@@ -148,21 +148,22 @@ function InnerCustomComponent(props: IProps) {
       }
       const { method, data, id } = payload;
       if (type === EventTypeEnum.Invoke) {
-        const fn = methodsRef.current[method];
-        if (!fn || typeof fn !== "function") {
+        if (methodsRef.current.hasOwnProperty(method) && typeof methodsRef.current[method] === "function") {
+          const fn = methodsRef.current[method];
+          fn(data).then((res: any) => {
+            sendMessage(iframe, {
+              type: EventTypeEnum.Invoke,
+              payload: {
+                id,
+                method,
+                response: res,
+              },
+            });
+          });
+        } else {
           // TODO: response error
           return;
         }
-        fn(data).then((res: any) => {
-          sendMessage(iframe, {
-            type: EventTypeEnum.Invoke,
-            payload: {
-              id,
-              method,
-              response: res,
-            },
-          });
-        });
       }
     };
 


### PR DESCRIPTION
Fixes [https://github.com/limskey/openblocks/security/code-scanning/3](https://github.com/limskey/openblocks/security/code-scanning/3)

To fix the problem, we need to ensure that the `method` is a valid key in `methodsRef.current` and that the corresponding value is a function before invoking it. This can be achieved by using the `hasOwnProperty` method to check if `method` is a valid key and then verifying that the value is a function.

- Add a check to verify that `method` is a valid key in `methodsRef.current` using `hasOwnProperty`.
- Ensure that the value corresponding to `method` is a function before invoking it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
